### PR TITLE
Major rewrite

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,10 @@ library that provide an easy-to-use user interface on the command line
 to the Nessus server. It can be used by itself, integrated into other
 scripts, or used as a reference.
 
+*nessusapi* was recently rewriten to be more pythonic, and *nessusinterface*
+is now broken. Additionally, the tests need re-writing as the functionality
+they tested has since been removed.
+
 pynessus-api aims to support Python 2.6+ and Python 3+
 
 =======
@@ -22,10 +26,10 @@ with the goal of being integrated with the `Nessus Parser`_.
 To-Do
 =====
 
-* Increase test coverage
-* Improve API support (nessusapi)
+* Re-create tests
+* Re-create interface module
+* Improve API coverage (nessusapi)
 * Create full CLI interface
-* Add support for multiple, simultaneously active sessions
 
 .. _Ruby Nessus API: https://github.com/sait-berkeley-infosec/nessus_api
 

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ library that provide an easy-to-use user interface on the command line
 to the Nessus server. It can be used by itself, integrated into other
 scripts, or used as a reference.
 
-*nessusapi* was recently rewriten to be more pythonic. The tests need
-re-writing as the functionality they tested has since been altered.
+*nessusapi* was recently rewriten to be more pythonic. This may have
+caused serious breaking changes in existing code.
 
 pynessus-api aims to support Python 2.6+ and Python 3+
 
@@ -25,9 +25,9 @@ with the goal of being integrated with the `Nessus Parser`_.
 To-Do
 =====
 
-* Re-create tests
 * Improve API coverage (nessusapi)
-* Create full CLI interface
+* Improve test coverage (tests)
+* Create full CLI interface (nessusinterface)
 
 .. _Ruby Nessus API: https://github.com/sait-berkeley-infosec/nessus_api
 

--- a/README.rst
+++ b/README.rst
@@ -9,9 +9,8 @@ library that provide an easy-to-use user interface on the command line
 to the Nessus server. It can be used by itself, integrated into other
 scripts, or used as a reference.
 
-*nessusapi* was recently rewriten to be more pythonic, and *nessusinterface*
-is now broken. Additionally, the tests need re-writing as the functionality
-they tested has since been removed.
+*nessusapi* was recently rewriten to be more pythonic. The tests need
+re-writing as the functionality they tested has since been altered.
 
 pynessus-api aims to support Python 2.6+ and Python 3+
 
@@ -27,7 +26,6 @@ To-Do
 =====
 
 * Re-create tests
-* Re-create interface module
 * Improve API coverage (nessusapi)
 * Create full CLI interface
 

--- a/nessusapi/__init__.py
+++ b/nessusapi/__init__.py
@@ -1,0 +1,7 @@
+# coding=utf-8
+
+from .nessus import Nessus
+from .report import Report, Host
+from .scan import Scan
+from .vulnerability import Vulnerability
+

--- a/nessusapi/nessus.py
+++ b/nessusapi/nessus.py
@@ -5,7 +5,7 @@ from nessusapi.session import Session
 from nessusapi.report import Host, Report
 from nessusapi.vulnerability import Vulnerability
 
-class Nessus:
+class Nessus(object):
     def __init__(self, user, pw, host='localhost', port=8834, verifySSL=True):
         """Create a session and make it the active one"""
         self.session = Session(user, pw, host=host, port=port, verifySSL=verifySSL)

--- a/nessusapi/nessus.py
+++ b/nessusapi/nessus.py
@@ -10,9 +10,6 @@ class Nessus(object):
         """Create a session and make it the active one"""
         self.session = Session(user, pw, host=host, port=port, verifySSL=verifySSL)
 
-    def __del__(self):
-        self.logout()
-    
     @classmethod
     def from_env(cls):
         # os.environ throws an error if the key is not present

--- a/nessusapi/nessus.py
+++ b/nessusapi/nessus.py
@@ -1,0 +1,74 @@
+import os
+import xmltodict
+
+from nessusapi.session import Session
+from nessusapi.report import Host, Report
+from nessusapi.vulnerability import Vulnerability
+
+class Nessus:
+    def __init__(self, user, pw, host='localhost', port=8834, verifySSL=True):
+        """Create a session and make it the active one"""
+        self.session = Session(user, pw, host=host, port=port, verifySSL=verifySSL)
+
+    def __del__(self):
+        self.logout()
+    
+    @classmethod
+    def from_env(cls):
+        # os.environ throws an error if the key is not present
+        user = os.environ['NESSUS_USERNAME']
+        pw   = os.environ['NESSUS_PASSWORD']
+        # os.getenv does not throw errors, and allows for a default value
+        host = os.getenv('NESSUS_HOST', 'localhost')
+        port = os.getenv('NESSUS_PORT', 8834)
+        verifySSL = os.getenv('NESSUS_VERIFYSSL', True)
+
+        return cls(user, pw, host=host, port=port, verifySSL=verifySSL)
+
+    def logout(self):
+        """Log out of the API and invalidate the token"""
+        self.session.close()
+    
+    @property
+    def reports(self):
+        raw_list = self.request_list('report/list', 'reports', 'report')
+
+        reports = []
+        for report in raw_list:
+            r = Report(nessus=self, uuid=report['name'])
+            r.timestamp = int(report['timestamp'])
+            r.status = report['status']
+            r.name = report['readableName']
+            reports.append(r)
+        
+        return reports
+
+    def _host_details(self, report, host):
+        tcp_list = request_list(self._request('report/details', report=report.uuid, hostname=host.hostname, protocol='tcp')['portDetails']['ReportItem'])
+        udp_list = request_list(self._request('report/details', report=report.uuid, hostname=host.hostname, protocol='udp')['portDetails']['ReportItem'])
+        return tcp_list + udp_list
+
+    def _request(self, path, **kwargs):
+        return self.session.request(path, **kwargs)
+
+    def request_list(self, path, *keys, **kwargs):
+        try:
+            request = self._request(path, **kwargs)
+            for key in keys:
+                request = request[key]
+            return _ensure_list(request)
+        except TypeError:
+            return []
+
+# requests sometimes do not return lists, so use this to make them lists
+def _ensure_list(obj):
+    if not isinstance(obj, list):
+        return [obj]
+    return obj
+
+class ConnectionError(Exception):
+    pass
+
+class AuthenticationError(Exception):
+    pass
+

--- a/nessusapi/nessus.py
+++ b/nessusapi/nessus.py
@@ -3,9 +3,9 @@
 import os
 import xmltodict
 
-from nessusapi.session import Session
-from nessusapi.report import Host, Report
-from nessusapi.vulnerability import Vulnerability
+from .session import Session
+from .report import Host, Report
+from .vulnerability import Vulnerability
 
 class Nessus(object):
     def __init__(self, user, pw, host='localhost', port=8834, verifySSL=True):

--- a/nessusapi/nessus.py
+++ b/nessusapi/nessus.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 import os
 import xmltodict
 
@@ -50,6 +52,12 @@ class Nessus(object):
 
     def _request(self, path, **kwargs):
         return self.session.request(path, **kwargs)
+
+    def request_single(self, path, *keys, **kwargs):
+        request = self._request(path, **kwargs)
+        for key in keys:
+            request = request[key]
+        return request
 
     def request_list(self, path, *keys, **kwargs):
         try:

--- a/nessusapi/report.py
+++ b/nessusapi/report.py
@@ -1,62 +1,138 @@
-from nessusapi.session import request
+import time
 
-def list_reports():
-    """
-    Return a list of available reports from the Nessus server.
+from nessusapi.utils import multiton
+from nessusapi.vulnerability import Vulnerability
 
-    Each report is an OrderedDict with the following useful fields:
-    timestamp -- the time the scan was created, as POSIX time
-    status -- the status of the report, e.g. 'completed'
-    name -- the uuid of the report
-    readableName -- the human-readable name specified for the report
-    """
-    return _ensure_list(request('report/list')['reports']['report'])
+@multiton
+class Report:
+    def __init__(self, nessus, uuid):
+        self.nessus = nessus
+        self.uuid = uuid
 
-def download_report(report):
-    """
-    Return the entirety of a Nessus report - which is a glorified
-    XML file. There is no filtering, and can be used to save directly
-    to a file.
-    """
-    return request('file/report/download')
+        self.timestamp = None
+        self.name = None
 
-def list_hosts(report):
-    """
-    Return a list of hosts included in a specified report uuid. 
+        self._status = None
+        self._completed = False # lets us know if the caches need to be updated
 
-    Each host is an OrderedDict with many fields, but the most useful
-    one is:
-    hostname -- the hostname of the host (e.g. server1.domain.org)
-    """
-    return _ensure_list(request('report/hosts', report=report)['hostList']['host'])
+        # Caches
+        self.hosts_list = [] 
+        self.vulns_list = []
+    
+    @property
+    def status(self):
+        if self._status != 'completed':
+            self.nessus.reports # force cache update
+        return self._status
 
-def list_vulns(report):
-    """
-    Return a list of vulnerabilities included in a specified report uuid.
+    @status.setter
+    def status(self, value):
+        if self._status != 'completed' and value == 'completed':
+            # Invalidate the caches
+            self._completed = True
+            self.hosts_list = None
+            self.vulns_list = None 
 
-    Each vuln is an OrderedDict with the following useful fields:
-    plugin_id -- numeric ID by which Nessus identifies the plugin 
-    plugin_name -- the human-readable name for the plugin
-    plugin_family -- the family which the plugin is in, e.g. 'DNS'
-    count -- the number of occurrences of the vulnerability in the report
-    severity -- the severity from 0 to 5, 0 being the least severe
-    """
-    return _ensure_list(request('report2/vulnerabilities', report=report)['vulnList']['vulnerability'])
+        self._status = value
 
-def list_affected_hosts(report, plugin, severity):
-    """
-    Return a list of hosts affected by a specified plugin.
+    @property
+    def hosts(self):
+        if not self.hosts_list or not self._completed:
+            self.hosts_list = self._list_hosts()
+        return self.hosts_list
 
-    For some reason, Nessus requires that the severity also be included.
-    Each host is an OrderedDict with the following useful fields:
-    hostname -- the hostname of the host (e.g. server1.domain.org)
-    port -- the port to which the plugin applies
-    protocol -- the protocol (typically tcp or udp) to which the plugin applies
-    """
-    return _ensure_list(request('report2/hosts/plugin', report=report, plugin_id=plugin, severity=severity)['hostList']['host'])
+    @property
+    def vulns(self):
+        if not self.vulns_list or not self._completed:
+            self.vulns_list = self._list_vulns()
+        return self.vulns_list
 
-# requests sometimes do not return lists, so make them lists
-def _ensure_list(obj):
-    if not isinstance(obj, list):
-        return [obj]
-    return obj
+    def _list_hosts(self):
+        """
+        Return a list of hosts included in a specified report uuid. 
+        """
+        raw_list = self.nessus.request_list('report2/hosts', 'hostList', 'host', report=self.uuid)
+
+        hosts = []
+        for host in raw_list:
+            h = Host(nessus=self.nessus, report=self, hostname=host['hostname'])
+            h.total = host['severity']
+            level_counts = host['severityCount']['item']
+            h.counts = ( level_counts[0], level_counts[1], level_counts[2],
+                         level_counts[3], level_counts[4] )
+
+            hosts.append(h)
+        
+        return hosts
+
+    def _list_vulns(self):
+        """
+        Return a list of vulnerabilities included in a specified report
+        """
+        raw_list = self.nessus.request_list('report2/vulnerabilities', 'vulnList', 'vulnerability', report=self.uuid)
+        
+        vulns = []
+        for vuln in raw_list:
+            v = Vulnerability(nessus=self.nessus, plugin_id=vuln['plugin_id'], severity=vuln['severity'])
+            v._name = vuln['plugin_name'] # unsafe, should use proper setters
+            v._family = vuln['plugin_family']
+            vulns.append(v)
+
+        return vulns
+    
+    def hosts_affected_by(self, vuln):
+        raw_list = self.nessus.request_list('report2/hosts/plugin', 'hostList', 'host', report=self.uuid, severity=vuln.severity, plugin_id=vuln.plugin_id)
+
+        hosts = []
+        for host in raw_list:
+            h = Host(nessus=self.nessus, report=self, hostname=host['hostname'])
+            hosts.append(h)
+
+        return hosts
+
+    def __str__(self):
+        timestamp = time.strftime(
+            "%Y-%m-%d %H:%M:%S",
+            time.localtime(self.timestamp))
+        return """Report "{0}" {1} ({2})""".format(
+               self.name, timestamp, self.status)
+    def __repr__(self):
+        return """Report({0}, {1}, {2}, {3})""".format(
+               self.timestamp, self.status, self.uuid, self.name)
+
+@multiton
+class Host:
+    def __init__(self, nessus, report, hostname): #, total, level_counts):
+        self.nessus = nessus
+        self.report = report
+        self.hostname = hostname
+
+        self.total = None
+        self.counts = None
+
+    @property
+    def info(self):
+        return self.counts[0]
+
+    @property
+    def low(self):
+        return self.counts[1]
+
+    @property
+    def med(self):
+        return self.counts[2]
+
+    @property
+    def high(self):
+        return self.counts[3]
+
+    @property
+    def critical(self):
+        return self.counts[4]
+
+    #def __str__(self):
+    #    return "Host {0}".format(self.hostname)
+
+    #def __repr__(self):
+    #    return "Host {0} [{1},{2},{3},{4},{5}]".format(self.hostname, self.info, self.low, self.med, self.high, self.critical)
+

--- a/nessusapi/report.py
+++ b/nessusapi/report.py
@@ -4,7 +4,7 @@ from nessusapi.utils import multiton
 from nessusapi.vulnerability import Vulnerability
 
 @multiton
-class Report:
+class Report(object):
     def __init__(self, nessus, uuid):
         self.nessus = nessus
         self.uuid = uuid
@@ -101,7 +101,7 @@ class Report:
                self.timestamp, self.status, self.uuid, self.name)
 
 @multiton
-class Host:
+class Host(object):
     def __init__(self, nessus, report, hostname): #, total, level_counts):
         self.nessus = nessus
         self.report = report

--- a/nessusapi/report.py
+++ b/nessusapi/report.py
@@ -1,7 +1,9 @@
+# coding=utf-8
+
 import time
 
-from nessusapi.utils import multiton
-from nessusapi.vulnerability import Vulnerability
+from .utils import multiton
+from .vulnerability import Vulnerability
 
 @multiton
 class Report(object):

--- a/nessusapi/scan.py
+++ b/nessusapi/scan.py
@@ -1,6 +1,6 @@
 from nessusapi.session import request, HTTPError 
 
-class Scan:
+class Scan(object):
     def __init__(self, target, scan_name, policy):
         self.target = target
         self.name = scan_name

--- a/nessusapi/scan.py
+++ b/nessusapi/scan.py
@@ -7,9 +7,6 @@ class Scan:
         self.policy = policy
         self.uuid = None
 
-    def start(self):
-        if self.uuid:
-            raise BadRequestError('Scan already started')
         try:
             self.uuid = request('scan/new', target=self.target,
                                         scan_name=self.name,
@@ -18,7 +15,7 @@ class Scan:
             if e.code == 404 and 'Unknown policy' in e.read():
                 raise BadRequestError('Unknown policy')
             raise
-        
+
     def stop(self):
         if self.changeStatus('stop') == 'stopping':
             self.uuid = None
@@ -36,3 +33,6 @@ class Scan:
             raise BadRequestError('Scan not started')
         return request('scan/{0}'.format(status),
                        scan_uuid=self.uuid)['scan']['status']
+
+class BadRequestError(Exception):
+    pass

--- a/nessusapi/session.py
+++ b/nessusapi/session.py
@@ -1,10 +1,7 @@
-import random
-# try python 3 imports, fall back to python 2
-
 import requests
 import xmltodict
 
-class Session:
+class Session(object):
     def __init__(self, user, pw, host, port, verifySSL=True):
         """Create a session and make it the active one"""
         self.host = host

--- a/nessusapi/session.py
+++ b/nessusapi/session.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 import requests
 import xmltodict
 

--- a/nessusapi/session.py
+++ b/nessusapi/session.py
@@ -12,7 +12,7 @@ class Session(object):
     def close(self):
         """Log out of the API and invalidate the token"""
         if self.token is None:
-            return True
+            raise AuthenticationError('Invalid session')
         if self.request('logout') == 'OK':
             self.token = None
             return True
@@ -21,12 +21,15 @@ class Session(object):
     def request(self, path, **kwargs):
         """Make a request to a path with specified kwargs"""
         if hasattr(self, 'token'):
-            kwargs['token'] = self.token 
+            kwargs['token'] = self.token
+        elif path != 'login':
+            raise AuthenticationError('Invalid session')
 
         url = 'https://{0}:{1}/{2}'.format(self.host,self.port,path)
         r = requests.post(url, verify=self.verifySSL, data=kwargs)
+
         if r.status_code != requests.codes.ok:
-            raise r.raise_for_status()
+            r.raise_for_status()
 
         response_data = xmltodict.parse(r.text)['reply']
         if response_data['status'] != 'OK':

--- a/nessusapi/template.py
+++ b/nessusapi/template.py
@@ -1,4 +1,6 @@
-from nessusapi.session import request
+# coding = utf-8
+
+from .session import request
 
 class Template:
     # startTime is scan start date (ISO format)

--- a/nessusapi/utils.py
+++ b/nessusapi/utils.py
@@ -1,0 +1,72 @@
+import inspect
+
+def multiton(cls):
+    """
+    Class decorator to make a class a multiton.
+    That is, there will be only (at most) one object existing for a given set
+    of initialization parameters.
+    """
+    instances = {}
+    def getinstance(*args, **kwargs):
+        key = _gen_key(cls, *args, **kwargs)
+                
+        if key not in instances:
+            instances[key] = cls(*args, **kwargs)
+        return instances[key]
+    return getinstance
+
+kwd_mark = (object(), ) # seperate args and kwargs with a unique object
+def _gen_key(cls, *args, **kwargs):
+    new_args, new_kwargs = _normalize_args(cls.__init__, *args, **kwargs)
+
+    key = new_args
+    if new_kwargs:
+        key += kwd_mark
+        sorted_items = sorted(new_kwargs.items())
+        for item in sorted_items:
+            key += item
+    return tuple(key)
+
+def _normalize_args(func, *args, **kwargs):
+    try:
+        arg_names, _, _, arg_defaults = inspect.getargspec(func)
+    except AttributeError: # cls has no __init__
+        arg_names = ['self']
+        arg_defaults = ()
+    arg_names = arg_names[1:] # skip first arg (self)
+    if arg_defaults is None:
+        arg_defaults = ()
+
+    new_args = []
+    new_kwargs = {}
+
+    # match named args to names
+    for name, arg in zip(arg_names, args):
+        new_kwargs[name] = arg
+
+    # handle extra args from *
+    if len(args) > len(arg_names):
+        for arg in args[len(arg_names):]:
+            new_args.append(arg)
+    # or fill in default values
+    else:
+        for name, default in zip(arg_names[len(args):], arg_defaults):
+            new_kwargs[name] = default
+
+    # merge remaining **kwargs
+    new_kwargs.update(kwargs)
+
+    return new_args, new_kwargs
+
+"""@multiton
+class A():
+    def __init__(self, a, b=10, *args, **kwargs):
+        self.a = a
+        self.b = b
+
+A(1)
+A(1, 10)
+A(1, b=10)
+A(1, 10, 11, 12, 13)
+A(1, 10, 11, 12, 13, d=14, e=15, f=16)
+A(1, b=10, d=14, e=15, f=16)"""

--- a/nessusapi/utils.py
+++ b/nessusapi/utils.py
@@ -58,15 +58,3 @@ def _normalize_args(func, *args, **kwargs):
 
     return new_args, new_kwargs
 
-"""@multiton
-class A():
-    def __init__(self, a, b=10, *args, **kwargs):
-        self.a = a
-        self.b = b
-
-A(1)
-A(1, 10)
-A(1, b=10)
-A(1, 10, 11, 12, 13)
-A(1, 10, 11, 12, 13, d=14, e=15, f=16)
-A(1, b=10, d=14, e=15, f=16)"""

--- a/nessusapi/utils.py
+++ b/nessusapi/utils.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 import inspect
 
 def multiton(cls):

--- a/nessusapi/vulnerability.py
+++ b/nessusapi/vulnerability.py
@@ -1,0 +1,43 @@
+from nessusapi.utils import multiton
+
+@multiton
+class Vulnerability(object):
+    def __init__(self, nessus, plugin_id, severity):
+        self.nessus = nessus
+        self.plugin_id = int(plugin_id)
+        self.severity = int(severity)
+
+        self._name = None
+        self._family = None
+
+    @property
+    def name(self):
+        if self._name is None:
+            self._set_name_and_family()
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
+    
+    @property
+    def family(self):
+        if self._family is None:
+            self._set_name_and_family()
+        return self._family
+
+    @family.setter
+    def family(self, value):
+        self._family = value
+
+    def _set_name_and_family(self):
+        data = self.nessus._request('plugins/attributes/pluginSearch', **{'filter.0.quality':'match', 'filter.0.value': self.id, 'filter.0.filter':'plugin_id'})['pluginList']['plugin']
+        assert int(data['pluginID']) == self.plugin_id, "Recieved plugin ID doesn't match."
+        self._name = data['pluginName']
+        self._family = data['pluginFamily']
+
+    def __str__(self):
+        return "Vuln {0}: {1} [{2}]".format(self.id, self.name, self.severity)
+
+# >>> request('plugins/attributes/pluginSearch', **{"filter.0.quality":"match", "filter.0.value":"80494","filter.0.filter":"plugin_id"}) 
+# OrderedDict([(u'pluginList', OrderedDict([(u'plugin', OrderedDict([(u'pluginFileName', u'smb_nt_ms15-005.nasl'), (u'pluginID', u'80494'), (u'pluginName', u'MS15-005: Vulnerability in Network Location Awareness Service Could Allow Security Feature Bypass (3022777)'), (u'pluginFamily', u'Windows : Microsoft Bulletins')]))]))]) 

--- a/nessusapi/vulnerability.py
+++ b/nessusapi/vulnerability.py
@@ -1,4 +1,6 @@
-from nessusapi.utils import multiton
+# coding=utf-8
+
+from .utils import multiton
 
 @multiton
 class Vulnerability(object):

--- a/nessusinterface/__init__.py
+++ b/nessusinterface/__init__.py
@@ -1,0 +1,4 @@
+# coding=utf-8
+
+from .session import authenticate
+from .report import select_report, get_reports_between

--- a/nessusinterface/report.py
+++ b/nessusinterface/report.py
@@ -1,13 +1,16 @@
 import time
 
-from nessusapi.report import list_reports
+from nessusinterface.session import authenticate
 
-def select_report():
+def select_report(nessus=None):
     """
     Present a command line interface to easily select a report from the
     report Nessus server, and return the report's UUID.
     """
-    report_data = list_reports()
+    if nessus is None:
+        nessus = authenticate()
+
+    report_data = nessus.reports
     reports = [report for report in report_data]
     reports.reverse()
 
@@ -23,9 +26,9 @@ def select_report():
             try:
                 timestamp = time.strftime(
                     "%Y-%m-%d %H:%M:%S",
-                    time.localtime(int(reports[index+i]['timestamp'])))
-                name = reports[index+i]['readableName']
-                status = reports[index+i]['status']
+                    time.localtime(int(reports[index+i].timestamp)))
+                name = reports[index+i].name
+                status = reports[index+i].status
                 # list each report with the format:
                 # [#] (date) Report Name {status}
                 # {status} is only shown if it is not 'completed'
@@ -54,7 +57,7 @@ def select_report():
           
     return reports[index+selected]
 
-def get_reports_between(start, end):
+def get_reports_between(start, end, nessus=None):
     """
     Go through all of the reports available to us. Carve out
     the ones that are between start and end, which are both
@@ -62,18 +65,20 @@ def get_reports_between(start, end):
 
     Returns an array of all reports within the given timeframe.
     """
-    report_data = list_reports()
-    reports = [report for report in report_data]
+    if nessus is None:
+        nessus = authenticate()
+
+    reports = nessus.reports
     reports.reverse()
     selected_reports = []
 
     for report in reports:
-        report_time = time.mktime(time.localtime(int(report['timestamp'])))
+        report_time = time.mktime(time.localtime(int(report.timestamp)))
         timestamp = time.strftime(
             "%Y-%m-%d %H:%M:%S",
-            time.localtime(int(report['timestamp'])))
-        name = report['readableName']
-        status = report['status']
+            time.localtime(int(report.timestamp)))
+        name = report.name
+        status = report.status
         if start < report_time < end and status == 'completed':
             print("Found report: ({0}) {1}".format(
                 timestamp, name))

--- a/nessusinterface/report.py
+++ b/nessusinterface/report.py
@@ -1,6 +1,8 @@
+# coding=utf-8
+
 import time
 
-from nessusinterface.session import authenticate
+from .session import authenticate
 
 def select_report(nessus=None):
     """

--- a/nessusinterface/session.py
+++ b/nessusinterface/session.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from getpass import getpass
 import os
 

--- a/nessusinterface/session.py
+++ b/nessusinterface/session.py
@@ -1,16 +1,15 @@
 from getpass import getpass
 import os
 
-from nessusapi.session import Session
+from nessusapi.nessus import Nessus
 
 def authenticate():
     print("Connecting to Nessus API")
     host=os.getenv('NESSUS_HOST') or _prompt("Host", "127.0.0.1")
     port=os.getenv('NESSUS_PORT') or _prompt("Port", "8834")
-    Session(os.getenv('NESSUS_USER') or _prompt("Username"),
-            os.getenv('NESSUS_PASS') or _prompt("Password", hidden=True),
-            host,
-            port)
+    user=os.getenv('NESSUS_USER') or _prompt("Username")
+    pass_=os.getenv('NESSUS_PASS') or _prompt("Password", hidden=True)
+    return Nessus(user, pass_, host, port)
 
 def _prompt(text, default=None, hidden=False):
     choice = ""

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 tests_require = [
     'mock >= 1.0.1',
+    'nose >= 1.3.4',
 ]
 
 install_requires = [

--- a/tests/test_nessus.py
+++ b/tests/test_nessus.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
+import unittest
+import nessusapi.nessus
+
+class TestNessus(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.real_session = nessusapi.nessus.Session
+        nessusapi.nessus.Session = mock.Mock()
+
+    @classmethod
+    def tearDownClass(cls):
+        nessusapi.nessus.Session = cls.real_session
+
+    def test_init(self):
+        mock_session = nessusapi.nessus.Session
+        nessusapi.nessus.Nessus('user', 'pw')
+        mock_session.assert_called_with('user', 'pw', host='localhost',
+                                        port=8834, verifySSL=True)
+
+        nessusapi.nessus.Nessus('user', 'pw', port=80)
+        mock_session.assert_called_with('user', 'pw', host='localhost',
+                                        port=80, verifySSL=True)
+
+        nessusapi.nessus.Nessus('user', 'pw', 'host', 30, False)
+        mock_session.assert_called_with('user', 'pw', host='host',
+                                        port=30, verifySSL=False)
+
+
+    @mock.patch('nessusapi.nessus.Nessus.request_list')
+    def test_reports(self, mock_request_list):
+        nessus = nessusapi.nessus.Nessus('user', 'pw')
+
+        mock_request_list.return_value = []
+        reports = nessus.reports
+        self.assertEqual(reports, [])
+        mock_request_list.assert_called_with('report/list', 'reports',
+                                             'report')
+
+        mock_request_list.return_value = [{'name': '123-ab', 'timestamp': '5',
+                                           'readableName': 'report1',
+                                           'status': 'completed'}]
+        reports = nessus.reports
+        self.assertEqual(len(reports), 1)
+        self.assertEqual(reports[0].uuid, '123-ab')
+        self.assertEqual(reports[0].timestamp, 5)
+        self.assertEqual(reports[0].name, 'report1')
+        self.assertEqual(reports[0].status, 'completed')
+
+        mock_request_list.return_value = [{'name': '321-ba', 'timestamp': '5',
+                                           'readableName': 'report2',
+                                           'status': 'completed'},
+                                          {'name': '456-de', 'timestamp': '21',
+                                           'readableName': 'report3',
+                                           'status': 'stopped'}]
+
+        reports = nessus.reports
+        self.assertEqual(len(reports), 2)
+
+

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,29 +1,25 @@
-#!/usr/bin/env python
 # coding=utf-8
 
 try:
     import unittest.mock as mock
 except ImportError:
     import mock
+
 import unittest
-try: 
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+import nessusapi.scan
 
-from nessusapi.scan import Scan
-from nessusapi.session import Session
-
-class SessionTestCase(unittest.TestCase):
+class TestScan(unittest.TestCase):
     def test_init(self):
-        fake_session = mock.MagicMock(Session)
-        fake_session.request.return_value = {'uuid': 'e3b4f63f-de03-ec8b'}
-        scan = Scan('192.0.2.9', 'TestScan', '5', fake_session)
+        fake_nessus = mock.Mock(request_single=
+                                mock.Mock(return_value='e3b4f63f-de03-ec8b'))
+
+        scan = nessusapi.scan.Scan(fake_nessus,'192.0.2.9', 'TestScan', 5)
         self.assertEqual(scan.uuid, 'e3b4f63f-de03-ec8b')
-        fake_session.request.assert_called_with('scan/new',
+        fake_nessus.request_single.assert_called_with('scan/new',
+                                                'scan', 'uuid',
                                                 target='192.0.2.9',
                                                 scan_name='TestScan',
-                                                policy_id='5')
+                                                policy_id=5)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,70 +5,74 @@ try:
     import unittest.mock as mock
 except ImportError:
     import mock
+
 import unittest
-try: 
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+import nessusapi.session
 
-from nessusapi.session import Session
-from nessusapi.session import Request
+xml_login_success = ('<?xml version="1.0"?> <reply>'
+                     "<status>OK</status>"
+                     "<contents><token>abcdef01</token>"
+                     "<user>"
+                     "<name>admin</name>"
+                     "<admin>TRUE</admin>"
+                     "</user></contents>"
+                     "</reply>")
 
-class SessionTestCase(unittest.TestCase):
-    @mock.patch('nessusapi.session.random')
-    @mock.patch('nessusapi.session.urlopen')
-    @mock.patch('nessusapi.session.Request')
-    def test_request(self, mock_request, mock_urlopen, mock_random):
-        mock_random.randrange.return_value = 2813
-        mock_urlopen.return_value = StringIO('<?xml version="1.0"?> <reply>'
-                                             "<seq>2813</seq>"
-                                             "<status>OK</status>"
-                                             "<contents><token>abcdef01</token>"
-                                             "<user>"
-                                             "<name>admin</name>"
-                                             "<admin>TRUE</admin>"
-                                             "</user></contents>"
-                                             "</reply>")
-        session = Session('user', 'pass', '192.0.2.7', '8981')
-        mock_urlopen.return_value = StringIO('<?xml version="1.0"?> <reply>'
-                                             "<seq>2813</seq>"
-                                             "<status>OK</status>"
-                                             "<contents>OK</contents>"
-                                             "</reply>")
-        session.request('test/url', arg1="arg1value", arg2="arg2value")
-        mock_request.assert_called_with('https://192.0.2.7:8981/test/url',
-                                        'arg1=arg1value&arg2=arg2value'
-                                        '&token=abcdef01&seq=2813')
+xml_login_error   = ('<?xml version="1.0"?> <reply>'
+                     "<status>ERROR</status>"
+                     "<contents>Invalid login</contents>"
+                     "</reply>")
 
-    @mock.patch('nessusapi.session.random')
-    @mock.patch('nessusapi.session.urlopen')
-    @mock.patch('nessusapi.session.Request')
-    def test_auth(self, mock_request, mock_urlopen, mock_random):
-        mock_random.randrange.return_value = 2811
-        mock_urlopen.return_value = StringIO('<?xml version="1.0"?> <reply>'
-                                             "<seq>2811</seq>"
-                                             "<status>OK</status>"
-                                             "<contents><token>ce65ea7</token>"
-                                             "<user>"
-                                             "<name>admin</name>"
-                                             "<admin>TRUE</admin>"
-                                             "</user></contents>"
-                                             "</reply>")
-        session = Session('user', 'pass', '192.0.2.3', '8980')
-        mock_request.assert_called_once_with('https://192.0.2.3:8980/login',
-                                        'login=user&password=pass&seq=2811')
-        self.assertEqual(session.token, "ce65ea7")
+class TestSession(unittest.TestCase):
+    @mock.patch('nessusapi.session.Session.request')
+    def test_init(self, mock_request):
+        mock_request.return_value = {'token': 'test_token'}
 
-        mock_random.randrange.return_value = 2817
-        mock_urlopen.return_value = StringIO('<?xml version="1.0"?> <reply>'
-                                             "<seq>2817</seq>"
-                                             "<status>OK</status>"
-                                             "<contents>OK</contents>"
-                                             "</reply>")
-        self.assertTrue(session.close())
-        mock_request.assert_called_with('https://192.0.2.3:8980/logout',
-                                        'token=ce65ea7&seq=2817')
-        self.assertIsNone(session.token)
+        s = nessusapi.session.Session("user", "pwd", "host", 8834)
 
-if __name__ == '__main__':
-    unittest.main()
+        mock_request.assert_called_once_with("login",**{"login":"user",
+                                                        "password": "pwd"})
+
+        self.assertEqual(s.token, 'test_token')
+        self.assertEqual(s.host, 'host')
+        self.assertEqual(s.port, 8834)
+
+    @mock.patch('nessusapi.session.Session.request')
+    def test_close(self, mock_request):
+        from nessusapi.session import AuthenticationError 
+        mock_request.return_value = {'token': 'test_token'}
+        s = nessusapi.session.Session("user", "pwd", "host", 8834)
+        self.assertIsNotNone(s.token)
+        
+        mock_request.return_value = "OK"
+        self.assertTrue(s.close())
+        self.assertIsNone(s.token)
+        mock_request.assert_called_with("logout")
+
+        self.assertRaises(AuthenticationError, s.close)
+
+    @mock.patch('nessusapi.session.requests.post')
+    def test_request_failure(self, mock_post):
+        from requests.exceptions import ConnectionError
+        def _raise(ex):
+            raise ex
+
+        mock_post.return_value=mock.Mock(status_code=403,
+                                         raise_for_status=lambda: _raise(ConnectionError))
+        self.assertRaises(ConnectionError, nessusapi.session.Session,
+                          *("user", "pwd", "host", 8834))
+
+        mock_post.return_value=mock.Mock(status_code=501,
+                                         raise_for_status=lambda: _raise(ConnectionError))
+        self.assertRaises(ConnectionError, nessusapi.session.Session,
+                          *("user", "pwd", "host", 8834))
+
+    @mock.patch('nessusapi.session.requests.post')
+    def test_request_bad_login(self, mock_post):
+        from nessusapi.session import AuthenticationError 
+        mock_post.return_value=mock.Mock(status_code=200,
+                                         raise_for_status=lambda: None,
+                                         text=xml_login_error)
+        self.assertRaises(AuthenticationError, nessusapi.session.Session,
+                          *("user", "pwd", "host", 8834))
+


### PR DESCRIPTION
This is a major refactoring of this project with significant breaking changes and architectural redesign.

Significantly:
- There is **no longer a single, global session**.
- New instances should now be created via `nessusapi.Nessus` (instead of by instantiating a `nessusapi.session.Session`).
  - Alternatively, create a Nessus instance from the environment via `nessusapi.Nessus.from_env()`
- Reporting is changed entirely.
  - A `Report` is an object containing information about a report.
  - A `Host` is an object containing information about a specific host associated with a specific report.
  - A `Vulnerability` is an object containing information about a specific vulnerability.
  - A list of all `Report`s on a Nessus server may be obtained via `Nessus.reports`.
  - A list of all `Hosts`s associated with a report may be obtained via `Report.hosts`.
  - A list of all `Vulnerability`s associated with a host may be obtained via `Host.vulns`.
- Scan now requires a `nessusapi.Nessus` instance as an arg.

`nessusinterface` has been rewritten to use the new design. See it for a demonstration of how the new system works if there is confusion.

Tests have been updated as well, however coverage is still lacking.
